### PR TITLE
Don't wait for interval seconds before polling the first time

### DIFF
--- a/nibe_mqtt/service.py
+++ b/nibe_mqtt/service.py
@@ -131,7 +131,6 @@ class PollService:
         asyncio.create_task(self._loop())
 
     async def _loop(self):
-        await asyncio.sleep(self._interval)
         while True:
             await asyncio.sleep(5.0)
             for coil in self._coils:


### PR DESCRIPTION
I have set the interval to poll every 5 minutes. The initial delay makes testing config.yaml changes (to get the relevant set of coils) slow. It's not clear why this is needed.